### PR TITLE
Update PostgreSQL connection URL port in configuration

### DIFF
--- a/step-06/scripts/configure-postgresql.cli
+++ b/step-06/scripts/configure-postgresql.cli
@@ -6,6 +6,6 @@ module add --name=org.postgresql --resources=libs/postgresql-42.7.3.jar --depend
 
 reload
 
-data-source add --name=LLMJakartaPostgresDS --jndi-name=java:jboss/datasources/LLMJakartaPostgresDS --driver-name=postgres --connection-url=jdbc:postgresql://localhost:5432/llmjakarta --user-name=llmjakarta --password=llmjakarta
+data-source add --name=LLMJakartaPostgresDS --jndi-name=java:jboss/datasources/LLMJakartaPostgresDS --driver-name=postgres --connection-url=jdbc:postgresql://localhost:5435/llmjakarta --user-name=llmjakarta --password=llmjakarta
 
 reload


### PR DESCRIPTION
Changed the PostgreSQL connection URL port from 5432 to 5435 to reflect the correct database server configuration. This ensures proper connectivity and avoids potential issues during application runtime.